### PR TITLE
fix slantedBandWindow function

### DIFF
--- a/dtw/window.py
+++ b/dtw/window.py
@@ -157,5 +157,5 @@ def itakuraWindow(iw, jw, query_size, reference_size):
 
 
 def slantedBandWindow(iw, jw, query_size, reference_size, window_size):
-    diagj = (iw * reference.size / query.size)
-    return abs(jw - diagj) <= window.size;
+    diagj = (iw * reference_size / query_size)
+    return abs(jw - diagj) <= window_size;


### PR DESCRIPTION
This PR fixes a bug with incorrect variable names in `slantedBandWindow`.

The previous version had variable names such as `query.size` in it - notation which is common in R, but doesn't work in Python. This commit corrects these names to `query_size`, `reference_size` and `window_size`, respectively.