### PR TITLE
Added axes labels for dtwPlotTwoWay

### DIFF
--- a/dtw/dtwPlot.py
+++ b/dtw/dtwPlot.py
@@ -172,7 +172,10 @@ When ``offset`` is set values on the left axis only apply to the query.
         ax2.tick_params('y', colors='b')
     else:
         ax2 = ax
-
+    
+    ax.set_xlabel(xlab)
+    ax.set_ylabel(ylab)
+    
     ax.plot(times, xts, color='k', **kwargs)
     ax2.plot(times, yts, **kwargs)
 


### PR DESCRIPTION
Axes labels were not being added in the `dtwPlotTwoWay` function. This is now added.
