### PR TITLE
Modifed dtwPlotTwoWay to fix issues with small offsets (issue #22)

### DIFF
--- a/dtw/dtwPlot.py
+++ b/dtw/dtwPlot.py
@@ -167,27 +167,19 @@ When ``offset`` is set values on the left axis only apply to the query.
     yts = numpy.pad(yts,(0,maxlen-len(yts)),"constant",constant_values=numpy.nan)
 
     fig, ax = plt.subplots()
-    if offset != 0:
-        ax2 = ax.twinx()
-        ax2.tick_params('y', colors='b')
-    else:
-        ax2 = ax
     
     ax.set_xlabel(xlab)
     ax.set_ylabel(ylab)
     
     ax.plot(times, xts, color='k', **kwargs)
-    ax2.plot(times, yts, **kwargs)
+    ax.plot(times, yts - offset, **kwargs)      # Plot with offset applied
 
-    ql, qh = ax.get_ylim()
-    rl, rh = ax2.get_ylim()
-
-    if offset > 0:
-        ax.set_ylim(ql - offset, qh)
-        ax2.set_ylim(rl, rh + offset)
-    elif offset < 0:
-        ax.set_ylim(ql, qh - offset)
-        ax2.set_ylim(rl + offset, rh)
+    if offset != 0:
+        # Create an offset axis
+        ax2 = ax.twinx()
+        ax2.tick_params('y', colors='b')
+        ql, qh = ax.get_ylim()
+        ax2.set_ylim(ql + offset, qh + offset)
 
     # https://stackoverflow.com/questions/21352580/matplotlib-plotting-numerous-disconnected-line-segments-with-different-colors
     if match_indices is None:


### PR DESCRIPTION
# A potential fix for small offsets when using a two way plot #22

Reference time series is now plotted on the same axis as the query. In the event of a non-zero offset, the reference values are adjusted by the offset and an offset twin axis is generated with the same scale of the original axis. 

### NOTE: This changes how each time series appears different in scale and should be considered as a design question.  

For some alignments the two-way plot now looks different. Prior to the change, (with non-zero offset) each time series would be plot on its own axis and consequently would result in matplotlib auto-scaling each time series to best fit each axis. Time-series of different averages would then be shown to be of a similar average height. However, now they the time-series are being plot on the _same_ axis, differences in scale become much more apparent and true to the values of the data. 

Depending on the goal of the user/designers, this may or may not be beneficial. For example, if one was to look at two time-series with drastically differing averages and was trying to show common peaks between the two at certain time intervals while ignoring peak height, this could result in the alignment being much harder to see. Alternatively, if peak height was equally important as when peaks were present, then this change would result in a clearer graph. One could argue that pre-processing should be used normalize the data somewhat if the scales were originally different.

Before change with time series being of similar average heights:
![dtw scale original](https://user-images.githubusercontent.com/35415469/180311232-22b8d3cb-5697-4973-bf41-48078bfc8f85.png)

After change the reference time series has a much larger average. Additionally note the change in scale of the twin y axis:
![dtw scale fixed](https://user-images.githubusercontent.com/35415469/180311231-9dc43155-3211-4771-9281-2241b88aabe8.png)


