### PR TITLE
add xidx and yidx

### DIFF
--- a/dtw/dtw.py
+++ b/dtw/dtw.py
@@ -128,6 +128,7 @@ plot_type :
 
 
 def dtw(x, y=None,
+	xidx=None, yidx=None,
         dist_method="euclidean",
         step_pattern="symmetric2",
         window_type=None,
@@ -199,6 +200,10 @@ x :
     query vector *or* local cost matrix
 y : 
     reference vector, unused if `x` given as cost matrix
+xidx:
+    time-indexed sequence corresponding to the query vector
+yidx:
+    time-indexed sequence corresponding to the reference vector
 dist_method : 
     pointwise (local) distance function to use. 
 step_pattern : 
@@ -388,6 +393,13 @@ Asymmetric: visiting 1 is required twice
                             seed=precm,
                             win_args=window_args)
     gcm = DTW(gcm)  # turn into an object, use dot to access properties
+    
+    if xidx is None or yidx is None:
+        gcm.xidx = numpy.arange(len(x))
+        gcm.yidx = numpy.arange(len(y))
+    else:
+        gcm.xidx = numpy.array(xidx)
+        gcm.yidx = numpy.array(yidx)
 
     gcm.N = n
     gcm.M = m

--- a/dtw/dtwPlot.py
+++ b/dtw/dtwPlot.py
@@ -170,8 +170,8 @@ When ``offset`` is set values on the left axis only apply to the query.
     ax.set_xlabel(xlab)
     ax.set_ylabel(ylab)
     
-    ax.plot(xtimes, numpy.array(xts), color='k', **kwargs)
-    ax.plot(ytimes, numpy.array(yts) - offset, **kwargs)      # Plot with offset applied
+    ax.plot(d.xidx, numpy.array(xts), color='k', **kwargs)
+    ax.plot(d.yidx, numpy.array(yts) - offset, **kwargs)      # Plot with offset applied
 
     if offset != 0:
         # Create an offset axis
@@ -191,8 +191,8 @@ When ``offset`` is set values on the left axis only apply to the query.
 
     col = []
     for i in idx:
-        col.append([(d.index1[i], xts[d.index1[i]]),
-                    (d.index2[i], -offset + yts[d.index2[i]])])
+        col.append([(d.xidx[d.index1[i]], xts[d.index1[i]]),
+                    (d.yidx[d.index2[i]], -offset + yts[d.index2[i]])])
 
     lc = mc.LineCollection(col, linewidths=1, linestyles=":", colors=match_col)
     ax.add_collection(lc)
@@ -285,14 +285,14 @@ title_margin :
     ax = plt.subplot(gs[1])
     axq = plt.subplot(gs[3])
 
-    axq.plot(nn1, xts)  # query, horizontal, bottom
+    axq.plot(d.xidx, xts)  # query, horizontal, bottom
     axq.set_xlabel(xlab)
 
-    axr.plot(yts, mm1)  # ref, vertical
+    axr.plot(yts, d.yidx)  # ref, vertical
     axr.invert_xaxis()
     axr.set_ylabel(ylab)
 
-    ax.plot(d.index1, d.index2)
+    ax.plot(d.xidx[d.index1], d.yidx[d.index2])
 
     if match_indices is None:
         idx = []


### PR DESCRIPTION
I was using dtw-python's `dtwPlotThreeWay` and `dtwPlotTwoWay` to plot my desired angle sequence and the robotic arm's actual angle sequence prior to dtw, and found that I couldn't change the horizontal coordinates to my time series (each moment corresponds to the current desired angle and the robotic arm's actual angle), which would lead to the result in the image below:
![error](https://github.com/DynamicTimeWarping/dtw-python/assets/54769542/fa1372ae-fc4f-4080-bfc8-4b5ab82b384b)

Due to the control delay, the lengths of the actual angle sequence (black line) and the desired angle sequence (blue line) of the robotic arm differ by about ten times, so the final plotted graph cannot fully demonstrate the point-to-point matching relationship between the two angle sequences. Therefore I would like to align these two angle sequences by my own recorded time series, the result of this timeseries branch is as follows:
![correct](https://github.com/DynamicTimeWarping/dtw-python/assets/54769542/5d728253-8d96-4d06-aa56-a21d812d1734)

The plotting results before and after the `dtwPlotThreeWay` change are shown below:
![threeway_error](https://github.com/DynamicTimeWarping/dtw-python/assets/54769542/9606f180-0e24-439b-a46f-3792b855f2a7)

![threeway_correct](https://github.com/DynamicTimeWarping/dtw-python/assets/54769542/057f8aee-7f48-4a37-8b56-366b6d66fd99)

In the timeseries branch, I added xidx and yidx to replace d.index1 and d.index2 as the horizontal coordinates, and still use the original d.index when plotting the matching points. At the same time, xidx and yidx are defaulted to None, which is the same as in the previous matser branch. Meanwhile, xidx and yidx are defaulted to None, and then, as in the previous matser branch, when xidx and yidx are the actual time series of xts and yts, respectively, they will be plotted instead of the original horizontal coordinates.
In short, when calculating the dtw between two signal sequences of different lengths, the plots of dtwPlotThreeWay and dtwPlotTwoWay do not show all the information, and this branch can unify the reference to the horizontal coordinates when adding the corresponding time series of each of the two signal sequences, and thus show more information.
I hope that this suggestion can be added to a future version, thus compensating for the shortcomings when plotting two DTW graphs with large differences in length.